### PR TITLE
Use real mesh geometries for bolometer cameras

### DIFF
--- a/cherab/mastu/machine/mastu_cad_files.py
+++ b/cherab/mastu/machine/mastu_cad_files.py
@@ -3,8 +3,8 @@ import os
 
 from raysect.primitive import Mesh
 from raysect.optical.spectralfunction import ConstantSF
-from raysect.optical.material import AbsorbingSurface, Lambert
-from raysect.optical.library.metal import RoughTungsten, RoughBeryllium
+from raysect.optical.material import Lambert
+from raysect.optical.library.metal import RoughTungsten
 
 try:
     CADMESH_PATH = os.environ['CHERAB_CADMESH']
@@ -262,6 +262,10 @@ UPPER_DIVERTOR = UPPER_DIVERTOR_ARMOUR + UPPER_DIVERTOR_NOSE + UPPER_GAS_BAFFLE
 
 MASTU_FULL_MESH = ELM_COILS + PF_COILS + VACUUM_VESSEL + BEAM_DUMPS + CENTRE_COLUMN + LOWER_DIVERTOR + UPPER_DIVERTOR
 
+CORE_BOLOMETERS = [
+    (os.path.join(CADMESH_PATH, 'mast/mastu-full/diagnostics/CORE_poloidal_bolometer.rsm'), METAL),
+    (os.path.join(CADMESH_PATH, 'mast/mastu-full/diagnostics/CORE_tangential_bolometer.rsm'), METAL),
+]
 
 SXD_BOLOMETERS = [
     (os.path.join(CADMESH_PATH, 'mast/mastu-full/diagnostics/DIVERTOR_horizontal_bolometer.rsm'), METAL),
@@ -288,4 +292,3 @@ def import_mastu_mesh(world, override_material=None, metal_material=None, lamber
         directory, filename = os.path.split(mesh_path)
         mesh_name, ext = filename.split('.')
         Mesh.from_file(mesh_path, parent=world, material=material, name=mesh_name)
-

--- a/examples/bolometry/sensitivities/calculate_sensitivities.py
+++ b/examples/bolometry/sensitivities/calculate_sensitivities.py
@@ -115,7 +115,8 @@ def calculate_and_save_sensitivities(grid_name, camera, mesh_parts,
         file_name = "{}_{}_bolo.npy".format(
             grid_name.replace("_", "-"), camera.lower()
         )
-    bolo = load_default_bolometer_config(bolo_name, parent=world, shot=50000)
+    bolo = load_default_bolometer_config(bolo_name, parent=world, shot=50000,
+                                         override_material=AbsorbingSurface())
 
     if camera_transform is not None:
         bolo.transform = camera_transform * bolo.transform


### PR DESCRIPTION
Replace the CSG apertures with real mesh geometries, with an
overridable material property. This prepares for the removal of CSG
aperture support for bolometer cameras in Cherab core, and also
fixes a bug where the CSG apertures in the divertor bolometers were
partially obscuring each other, reducing the measured etendue of the
detectors.

Update the sensitivity demo to override the camera material, since we
aren't interested in reflections inside the bolometer camera for
tomography (yet...).

Fixes #9 